### PR TITLE
Feat: 유저별 루틴 관리 및 루틴 수정, 삭제 기능 구현

### DIFF
--- a/src/main/java/kr/sesacjava/swimtutor/routine/controller/RoutineController.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/controller/RoutineController.java
@@ -20,23 +20,28 @@ import java.util.List;
 public class RoutineController {
 
     private static final Logger LOG = LoggerFactory.getLogger(RoutineController.class);
-    private NewRoutineImpl newRoutineImpl;
-    private RoutineImpl routineImpl;
+    private final NewRoutineImpl newRoutineImpl;
+    private final RoutineImpl routineImpl;
 
     @Autowired
     public RoutineController(NewRoutineImpl newRoutineImpl, RoutineImpl routineImpl) {
-//        LOG.info("RoutineController 생성자 호출");
+        LOG.info("RoutineController 생성자 호출");
         this.newRoutineImpl = newRoutineImpl;
         this.routineImpl = routineImpl;
     }
 
-    // TODO: 유저별 루틴 목록 조회
-
     // 루틴 목록
-    @GetMapping
-    public List<ResponseRoutineDTO> getRoutines() {
+    @GetMapping("/all")
+    public List<ResponseRoutineDTO> getAllRoutines() {
 //        LOG.info("routineService getRoutines 호출");
-        return routineImpl.getRoutines();
+        return routineImpl.getAllRoutines();
+    }
+
+    // 유저별 루틴 목록 조회
+    @GetMapping("/list")
+    public List<ResponseRoutineDTO> getSeveralRoutines(@CurrentUser UserInfo userInfo) {
+        LOG.info("routineService getSeveralRoutines 호출");
+        return routineImpl.getSeveralRoutines(userInfo);
     }
 
     // 루틴 상세

--- a/src/main/java/kr/sesacjava/swimtutor/routine/controller/RoutineController.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/controller/RoutineController.java
@@ -2,8 +2,7 @@ package kr.sesacjava.swimtutor.routine.controller;
 
 import kr.sesacjava.swimtutor.routine.dto.RequestRoutineDTO;
 import kr.sesacjava.swimtutor.routine.dto.ResponseRoutineDTO;
-import kr.sesacjava.swimtutor.routine.dto.TrainingForRoutineDTO;
-import kr.sesacjava.swimtutor.routine.entity.id.RoutineId;
+import kr.sesacjava.swimtutor.routine.dto.ResponseRoutineDetailDTO;
 import kr.sesacjava.swimtutor.routine.service.NewRoutineImpl;
 import kr.sesacjava.swimtutor.routine.service.RoutineImpl;
 import kr.sesacjava.swimtutor.security.CurrentUser;
@@ -25,7 +24,7 @@ public class RoutineController {
 
     @Autowired
     public RoutineController(NewRoutineImpl newRoutineImpl, RoutineImpl routineImpl) {
-        LOG.info("RoutineController 생성자 호출");
+//        LOG.info("RoutineController 생성자 호출");
         this.newRoutineImpl = newRoutineImpl;
         this.routineImpl = routineImpl;
     }
@@ -47,18 +46,17 @@ public class RoutineController {
 
     // 루틴 상세
     @GetMapping("/{routineNo}")
-    public List<TrainingForRoutineDTO> getRoutineDetail(@CurrentUser UserInfo userInfo, @PathVariable Integer routineNo) {
+    public ResponseRoutineDetailDTO getRoutineDetail(
+            @CurrentUser UserInfo userInfo,
+            @PathVariable Integer routineNo) {
 //        LOG.info("routineDetailService getRoutineDetail 호출");
-        RoutineId routineId = new RoutineId(routineNo, userInfo.getEmail(), userInfo.getPlatform());
-        return routineImpl.getRoutineDetail(routineId);
+        return routineImpl.getRoutineDetail(userInfo, routineNo);
     }
 
     // 루틴 생성
     @PostMapping
     public void saveNewRoutine(@CurrentUser UserInfo userInfo, @RequestBody RequestRoutineDTO requestRoutineDTO) {
 //        LOG.info("routineService saveTrainingsForRoutine 호출");
-//        LOG.info("Received userInfo: {}", userInfo.toString());
-//        LOG.info("Received requestRoutineDTO: {}", requestRoutineDTO.toString());
         newRoutineImpl.saveNewRoutine(userInfo, requestRoutineDTO);
     }
 }

--- a/src/main/java/kr/sesacjava/swimtutor/routine/controller/RoutineController.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/controller/RoutineController.java
@@ -2,7 +2,7 @@ package kr.sesacjava.swimtutor.routine.controller;
 
 import kr.sesacjava.swimtutor.routine.dto.RequestRoutineDTO;
 import kr.sesacjava.swimtutor.routine.dto.ResponseRoutineDTO;
-import kr.sesacjava.swimtutor.routine.dto.ResponseRoutineDetailDTO;
+import kr.sesacjava.swimtutor.routine.dto.RoutineDetailDTO;
 import kr.sesacjava.swimtutor.routine.service.NewRoutineImpl;
 import kr.sesacjava.swimtutor.routine.service.RoutineImpl;
 import kr.sesacjava.swimtutor.security.CurrentUser;
@@ -46,7 +46,7 @@ public class RoutineController {
 
     // 루틴 상세
     @GetMapping("/{routineNo}")
-    public ResponseRoutineDetailDTO getRoutineDetail(
+    public RoutineDetailDTO getRoutineDetail(
             @CurrentUser UserInfo userInfo,
             @PathVariable Integer routineNo) {
 //        LOG.info("routineDetailService getRoutineDetail 호출");
@@ -58,5 +58,25 @@ public class RoutineController {
     public void saveNewRoutine(@CurrentUser UserInfo userInfo, @RequestBody RequestRoutineDTO requestRoutineDTO) {
 //        LOG.info("routineService saveTrainingsForRoutine 호출");
         newRoutineImpl.saveNewRoutine(userInfo, requestRoutineDTO);
+    }
+
+    // 루틴 수정
+    @PutMapping("/update/{routineNo}")
+    public void updateRoutine(@CurrentUser UserInfo userInfo, @PathVariable Integer routineNo, @RequestBody RequestRoutineDTO requestRoutineDTO) {
+//        LOG.info("routineService updateRoutine 호출");
+        try {
+            // 비즈니스 로직 수행
+            LOG.debug("Received update request: routineNo={}, request={}", routineNo, requestRoutineDTO);
+            routineImpl.updateRoutine(userInfo, routineNo, requestRoutineDTO);
+        } catch (Exception e) {
+            LOG.error("Failed to update routine: routineNo={}, request={}", routineNo, requestRoutineDTO, e);
+        }
+    }
+
+    // 루틴 삭제
+    @DeleteMapping("/{routineNo}")
+    public void deleteRoutine(@CurrentUser UserInfo userInfo, @PathVariable Integer routineNo) {
+//        LOG.info("routineService deleteRoutine 호출");
+        routineImpl.deleteRoutine(userInfo, routineNo);
     }
 }

--- a/src/main/java/kr/sesacjava/swimtutor/routine/controller/RoutineController.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/controller/RoutineController.java
@@ -34,13 +34,14 @@ public class RoutineController {
     @GetMapping("/all")
     public List<ResponseRoutineDTO> getAllRoutines() {
 //        LOG.info("routineService getRoutines 호출");
+
         return routineImpl.getAllRoutines();
     }
 
     // 유저별 루틴 목록 조회
     @GetMapping("/list")
     public List<ResponseRoutineDTO> getSeveralRoutines(@CurrentUser UserInfo userInfo) {
-        LOG.info("routineService getSeveralRoutines 호출");
+//        LOG.info("routineService getSeveralRoutines 호출");
         return routineImpl.getSeveralRoutines(userInfo);
     }
 

--- a/src/main/java/kr/sesacjava/swimtutor/routine/dto/ResponseRoutineDetailDTO.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/dto/ResponseRoutineDetailDTO.java
@@ -25,5 +25,5 @@ public class ResponseRoutineDetailDTO {
     // ResponseTrainingForRoutine
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "routine_no")
-    private List<TrainingForRoutineDTO> trainingForRoutineDTOS;
+    private List<TrainingForRoutineDTO> trainingData;
 }

--- a/src/main/java/kr/sesacjava/swimtutor/routine/dto/RoutineDetailDTO.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/dto/RoutineDetailDTO.java
@@ -13,7 +13,7 @@ import java.util.List;
 @ToString
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ResponseRoutineDetailDTO {
+public class RoutineDetailDTO {
     // Routine
     private String routineName;
     private Integer poolLength;

--- a/src/main/java/kr/sesacjava/swimtutor/routine/entity/Routine.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/entity/Routine.java
@@ -44,4 +44,11 @@ public class Routine {
 
     @Column(name = "updated")
     private LocalDateTime updated;
+
+    public void change(String routineName, int poolLength, int targetDistance, String selStrokes) {
+        this.routineName = routineName;
+        this.poolLength = poolLength;
+        this.targetDistance = targetDistance;
+        this.selStrokes = selStrokes;
+    }
 }

--- a/src/main/java/kr/sesacjava/swimtutor/routine/entity/RoutineSequenceUpdate.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/entity/RoutineSequenceUpdate.java
@@ -1,0 +1,23 @@
+package kr.sesacjava.swimtutor.routine.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "routine_sequence_update")
+public class RoutineSequenceUpdate {
+    @Id
+    private Long id;
+    private String oauthLoginId;
+    private String oauthLoginPlatform;
+    private int currentNo;
+}

--- a/src/main/java/kr/sesacjava/swimtutor/routine/repository/RoutineRepository.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/repository/RoutineRepository.java
@@ -12,8 +12,8 @@ import java.util.List;
 @Repository
 public interface RoutineRepository extends JpaRepository<Routine, RoutineId> {
     // 루틴 번호 최대값 조회 - 복합키는 IDENITITY 전략 사용 불가
-    @Query("SELECT MAX(r.routineNo) FROM Routine r")
-    Integer findMaxRoutineNo();
+    @Query("SELECT MAX(r.routineNo) FROM Routine r WHERE r.oauthLoginId = :#{#userInfo.email} AND r.oauthLoginPlatform = :#{#userInfo.platform}")
+    Integer findMaxRoutineNo(UserInfo userInfo);
 
     // 유저별 루틴 조회
     @Query("SELECT r FROM Routine r WHERE r.oauthLoginId = :#{#userInfo.email} AND r.oauthLoginPlatform = :#{#userInfo.platform}")

--- a/src/main/java/kr/sesacjava/swimtutor/routine/repository/RoutineRepository.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/repository/RoutineRepository.java
@@ -2,13 +2,20 @@ package kr.sesacjava.swimtutor.routine.repository;
 
 import kr.sesacjava.swimtutor.routine.entity.Routine;
 import kr.sesacjava.swimtutor.routine.entity.id.RoutineId;
+import kr.sesacjava.swimtutor.security.dto.UserInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface RoutineRepository extends JpaRepository<Routine, RoutineId> {
     // 루틴 번호 최대값 조회 - 복합키는 IDENITITY 전략 사용 불가
     @Query("SELECT MAX(r.routineNo) FROM Routine r")
     Integer findMaxRoutineNo();
+
+    // 유저별 루틴 조회
+    @Query("SELECT r FROM Routine r WHERE r.oauthLoginId = :#{#userInfo.email} AND r.oauthLoginPlatform = :#{#userInfo.platform}")
+    List<Routine> findByUser(UserInfo userInfo);
 }

--- a/src/main/java/kr/sesacjava/swimtutor/routine/repository/RoutineSequenceUpdateRepository.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/repository/RoutineSequenceUpdateRepository.java
@@ -1,0 +1,10 @@
+package kr.sesacjava.swimtutor.routine.repository;
+
+import kr.sesacjava.swimtutor.routine.entity.RoutineSequenceUpdate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.query.Procedure;
+
+public interface RoutineSequenceUpdateRepository extends JpaRepository<RoutineSequenceUpdate, Long> {
+    @Procedure("process_routine_update_queue")
+    void processRoutineUpdateQueue();
+}

--- a/src/main/java/kr/sesacjava/swimtutor/routine/repository/TrainingForRoutineRepository.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/repository/TrainingForRoutineRepository.java
@@ -2,12 +2,15 @@ package kr.sesacjava.swimtutor.routine.repository;
 
 import kr.sesacjava.swimtutor.routine.entity.TrainingForRoutine;
 import kr.sesacjava.swimtutor.routine.entity.id.TrainingForRoutineId;
+import kr.sesacjava.swimtutor.security.dto.UserInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface TrainingForRoutineRepository extends JpaRepository<TrainingForRoutine, TrainingForRoutineId> {
-    List<TrainingForRoutine> findAllByRoutineNo(Integer routineNo);
+    @Query("SELECT tfr FROM TrainingForRoutine tfr WHERE tfr.oauthLoginId = :#{#userInfo.email} AND tfr.oauthLoginPlatform = :#{#userInfo.platform} AND tfr.routineNo = :routineNo")
+    List<TrainingForRoutine> findAllByRoutineNo(UserInfo userInfo, Integer routineNo);
 }

--- a/src/main/java/kr/sesacjava/swimtutor/routine/service/NewRoutineImpl.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/service/NewRoutineImpl.java
@@ -166,7 +166,7 @@ public class NewRoutineImpl implements NewRoutineService {
 
         // 루틴 저장
         routineImpl.saveRoutine(userInfo, requestRoutineDTO);
-        int lastRoutineNo = routineRepo.findMaxRoutineNo() == null ? 0 : routineRepo.findMaxRoutineNo();
+        int lastRoutineNo = routineRepo.findMaxRoutineNo(userInfo) == null ? 0 : routineRepo.findMaxRoutineNo(userInfo);
         LOG.info("lastRoutineNo: {}", lastRoutineNo);
 
         Routine routine = Routine.builder()

--- a/src/main/java/kr/sesacjava/swimtutor/routine/service/RoutineImpl.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/service/RoutineImpl.java
@@ -35,7 +35,7 @@ public class RoutineImpl implements RoutineService {
 
     @Autowired
     public RoutineImpl(RoutineRepository routineRepo, TrainingRepository trainingRepo, TrainingForRoutineRepository trainingForRoutineRepo) {
-        LOG.info("RoutineImpl 생성자 호출");
+//        LOG.info("RoutineImpl 생성자 호출");
         this.routineRepo = routineRepo;
         this.trainingRepo = trainingRepo;
         this.trainingForRoutineRepo = trainingForRoutineRepo;
@@ -43,7 +43,7 @@ public class RoutineImpl implements RoutineService {
 
     // 루틴 조회
     public List<ResponseRoutineDTO> getRoutines(List<Routine> routines) {
-        LOG.info("getRoutines 호출");
+//        LOG.info("getRoutines 호출");
         List<ResponseRoutineDTO> responseRoutineDTOs = new ArrayList<>();
         for (Routine routine : routines) {
             ResponseRoutineDTO responseRoutineDTO = ResponseRoutineDTO.builder()
@@ -60,10 +60,11 @@ public class RoutineImpl implements RoutineService {
         return responseRoutineDTOs;
     }
 
-    // 루틴 목록
+    // 전체 루틴 목록
+    // TODO: UserInfo 추가
     @Override
     public List<ResponseRoutineDTO> getAllRoutines() {
-        LOG.info("getAllRoutines 호출");
+//        LOG.info("getAllRoutines 호출");
         List<Routine> routines = routineRepo.findAll();
         return getRoutines(routines);
     }
@@ -71,7 +72,7 @@ public class RoutineImpl implements RoutineService {
     // 유저별 루틴 목록 조회
     @Override
     public List<ResponseRoutineDTO> getSeveralRoutines(UserInfo userInfo) {
-        LOG.info("getSeveralRoutines 호출");
+//        LOG.info("getSeveralRoutines 호출");
         List<Routine> routines = routineRepo.findByUser(userInfo);
         return getRoutines(routines);
     }

--- a/src/main/java/kr/sesacjava/swimtutor/routine/service/RoutineImpl.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/service/RoutineImpl.java
@@ -35,16 +35,15 @@ public class RoutineImpl implements RoutineService {
 
     @Autowired
     public RoutineImpl(RoutineRepository routineRepo, TrainingRepository trainingRepo, TrainingForRoutineRepository trainingForRoutineRepo) {
-//        LOG.info("RoutineImpl 생성자 호출");
+        LOG.info("RoutineImpl 생성자 호출");
         this.routineRepo = routineRepo;
         this.trainingRepo = trainingRepo;
         this.trainingForRoutineRepo = trainingForRoutineRepo;
     }
 
-    // 루틴 목록
-    public List<ResponseRoutineDTO> getRoutines() {
-//        LOG.info("getRoutines 호출");
-        List<Routine> routines = routineRepo.findAll();
+    // 루틴 조회
+    public List<ResponseRoutineDTO> getRoutines(List<Routine> routines) {
+        LOG.info("getRoutines 호출");
         List<ResponseRoutineDTO> responseRoutineDTOs = new ArrayList<>();
         for (Routine routine : routines) {
             ResponseRoutineDTO responseRoutineDTO = ResponseRoutineDTO.builder()
@@ -61,8 +60,25 @@ public class RoutineImpl implements RoutineService {
         return responseRoutineDTOs;
     }
 
+    // 루틴 목록
+    @Override
+    public List<ResponseRoutineDTO> getAllRoutines() {
+        LOG.info("getAllRoutines 호출");
+        List<Routine> routines = routineRepo.findAll();
+        return getRoutines(routines);
+    }
+
+    // 유저별 루틴 목록 조회
+    @Override
+    public List<ResponseRoutineDTO> getSeveralRoutines(UserInfo userInfo) {
+        LOG.info("getSeveralRoutines 호출");
+        List<Routine> routines = routineRepo.findByUser(userInfo);
+        return getRoutines(routines);
+    }
+
     // 루틴 상세
     @Transactional
+    @Override
     public List<TrainingForRoutineDTO> getRoutineDetail(RoutineId routineId) {
 //        LOG.info("getRoutineDetail 호출");
         List<TrainingForRoutineDTO> trainingForRoutineDTOS = new ArrayList<>();
@@ -97,6 +113,7 @@ public class RoutineImpl implements RoutineService {
     }
 
     // 루틴 저장
+    @Override
     public Routine saveRoutine(UserInfo userInfo, RequestRoutineDTO requestRoutineDTO) {
 //        LOG.info("saveRoutine 호출");
         int lastRoutineNo = routineRepo.findMaxRoutineNo() == null ? 0 : routineRepo.findMaxRoutineNo();
@@ -115,6 +132,7 @@ public class RoutineImpl implements RoutineService {
     }
 
     // 루틴 삭제
+    @Override
     public Routine deleteRoutine(RoutineId routineId) {
 //        LOG.info("RoutineImpl - deleteRoutine 호출");
         Routine routine = routineRepo.findById(routineId).orElse(null);

--- a/src/main/java/kr/sesacjava/swimtutor/routine/service/RoutineService.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/service/RoutineService.java
@@ -11,8 +11,11 @@ import java.util.List;
 
 public interface RoutineService {
 
+    // 유저별 루틴 목록 조회
+    List<ResponseRoutineDTO> getSeveralRoutines(UserInfo userInfo);
+
     // 루틴 목록
-    List<ResponseRoutineDTO> getRoutines();
+    List<ResponseRoutineDTO> getAllRoutines();
 
     // 루틴 상세
     List<TrainingForRoutineDTO> getRoutineDetail(RoutineId routineId);

--- a/src/main/java/kr/sesacjava/swimtutor/routine/service/RoutineService.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/service/RoutineService.java
@@ -2,7 +2,7 @@ package kr.sesacjava.swimtutor.routine.service;
 
 import kr.sesacjava.swimtutor.routine.dto.RequestRoutineDTO;
 import kr.sesacjava.swimtutor.routine.dto.ResponseRoutineDTO;
-import kr.sesacjava.swimtutor.routine.dto.ResponseRoutineDetailDTO;
+import kr.sesacjava.swimtutor.routine.dto.RoutineDetailDTO;
 import kr.sesacjava.swimtutor.routine.entity.Routine;
 import kr.sesacjava.swimtutor.security.dto.UserInfo;
 
@@ -17,10 +17,13 @@ public interface RoutineService {
     List<ResponseRoutineDTO> getAllRoutines();
 
     // 루틴 상세
-    ResponseRoutineDetailDTO getRoutineDetail(UserInfo userInfo, Integer routineNo);
+    RoutineDetailDTO getRoutineDetail(UserInfo userInfo, Integer routineNo);
 
     // 루틴 저장
     Routine saveRoutine(UserInfo userInfo, RequestRoutineDTO requestRoutineDTO);
+
+    // 루틴 수정
+    void updateRoutine(UserInfo userInfo, Integer routineNo, RequestRoutineDTO requestRoutineDTO);
 
     // 루틴 삭제
     Routine deleteRoutine(UserInfo userInfo, Integer routineNo);

--- a/src/main/java/kr/sesacjava/swimtutor/routine/service/RoutineService.java
+++ b/src/main/java/kr/sesacjava/swimtutor/routine/service/RoutineService.java
@@ -2,9 +2,8 @@ package kr.sesacjava.swimtutor.routine.service;
 
 import kr.sesacjava.swimtutor.routine.dto.RequestRoutineDTO;
 import kr.sesacjava.swimtutor.routine.dto.ResponseRoutineDTO;
-import kr.sesacjava.swimtutor.routine.dto.TrainingForRoutineDTO;
+import kr.sesacjava.swimtutor.routine.dto.ResponseRoutineDetailDTO;
 import kr.sesacjava.swimtutor.routine.entity.Routine;
-import kr.sesacjava.swimtutor.routine.entity.id.RoutineId;
 import kr.sesacjava.swimtutor.security.dto.UserInfo;
 
 import java.util.List;
@@ -18,11 +17,11 @@ public interface RoutineService {
     List<ResponseRoutineDTO> getAllRoutines();
 
     // 루틴 상세
-    List<TrainingForRoutineDTO> getRoutineDetail(RoutineId routineId);
+    ResponseRoutineDetailDTO getRoutineDetail(UserInfo userInfo, Integer routineNo);
 
     // 루틴 저장
     Routine saveRoutine(UserInfo userInfo, RequestRoutineDTO requestRoutineDTO);
 
     // 루틴 삭제
-    Routine deleteRoutine(RoutineId routineId);
+    Routine deleteRoutine(UserInfo userInfo, Integer routineNo);
 }


### PR DESCRIPTION
## 1. MR 목적
- 루틴 상세 페이지 UI 변경
- 루틴 페이지에 노출되는 목록 유저별 목록으로 변경
- 루틴 상세 페이지에서 루틴명 및 레인 길이 변경할 수 있게 함

## 2. MR 내용
- 유저별 목록 노출하며 routine 테이블에서 routine_no 유저별로 넘버링 되도록 DB 변경함
- 상세페이지에서 훈련정보와 같이 다른 내용 수정 시 연결되어있는 내용들을 다수 변화시켜야 할 필요가 있어 복잡해지므로 일단 2개 항목만 변경하도록 구현함
- 루틴 삭제 구현을 위해 training_for_routine 테이블 fk에 cascade 적용

## 체크리스트 (Checklist)
- [x] 코드가 정상적으로 동작하는지 테스트를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 기존의 기능이 정상적으로 작동하는지 확인했습니다.
- [x] 스타일 가이드와 일관되게 코드를 작성했습니다.

## 테스트 결과 (Test Results)
- 테스트 방법을 설명해주세요 (예: `npm test` 또는 `./gradlew test`).
- 테스트를 통해 발견된 이슈가 있다면 기술해주세요.

## 추가 설명 (Additional Notes)
- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요.
  - 루틴 삭제 시 유저별 넘버링 초기화되지 않음
  - db에서 내부적으로 해결해보려 하였으나 정상 반영되지 않아 추가적인 작업 필요
- 코드 리뷰어가 주의해야 할 사항이 있다면 명시해주세요.

